### PR TITLE
allow overriding default jvm options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,8 +74,11 @@
 #
 #   See: https://www.elastic.co/guide/en/logstash/current/config-setting-files.html
 #
+# @param [Hash] jvm_options_defaults
+#   Default set of optionname => option mappings from upstream 8.5 version
+#
 # @param [Array] jvm_options
-#   A collection of settings to be defined in `jvm.options`.
+#   A collection of settings to be defined in `jvm.options`. Override same settings in jvm_options_defaults
 #
 # @param [Array] pipelines
 #   A collection of settings to be defined in `pipelines.yml`.
@@ -154,6 +157,17 @@ class logstash (
   $service_provider  = undef,
   $settings          = {},
   $startup_options   = {},
+  $jvm_options_defaults = {
+    '-Xms' => '-Xms1g',
+    '-Xmx' => '-Xmx1g',
+    'UseConcMarkSweepGC' => '11-13:-XX:+UseConcMarkSweepGC',
+    'CMSInitiatingOccupancyFraction=' => '11-13:-XX:CMSInitiatingOccupancyFraction=75',
+    'UseCMSInitiatingOccupancyOnly' => '11-13:-XX:+UseCMSInitiatingOccupancyOnly',
+    '-Djava.awt.headless=' => '-Djava.awt.headless=true',
+    '-Dfile.encoding=' => '-Dfile.encoding=UTF-8',
+    'HeapDumpOnOutOfMemoryError' => '-XX:+HeapDumpOnOutOfMemoryError',
+    '-Djava.security.egd' => '-Djava.security.egd=file:/dev/urandom',
+  },
   $jvm_options       = [],
   Array $pipelines   = [],
   Boolean $manage_repo   = true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -31,22 +31,10 @@ class logstash::service {
     'SERVICE_DESCRIPTION' => '"logstash"',
   }
 
-  $default_jvm_options = [
-    '-Dfile.encoding=UTF-8',
-    '-Djava.awt.headless=true',
-    '-Xms256m',
-    '-Xmx1g',
-    '-XX:CMSInitiatingOccupancyFraction=75',
-    '-XX:+DisableExplicitGC',
-    '-XX:+HeapDumpOnOutOfMemoryError',
-    '-XX:+UseCMSInitiatingOccupancyOnly',
-    '-XX:+UseConcMarkSweepGC',
-    '-XX:+UseParNewGC',
-  ]
-
   $settings = merge($default_settings, $logstash::settings)
   $startup_options = merge($default_startup_options, $logstash::startup_options)
   $jvm_options = $logstash::jvm_options
+  $jvm_options_defaults = $logstash::jvm_options_defaults
   $pipelines = $logstash::pipelines
 
   File {

--- a/templates/jvm.options.erb
+++ b/templates/jvm.options.erb
@@ -6,20 +6,7 @@ def set_default(options, match_string, default)
   options.detect {|o| o.include?(match_string)} || options.push(default)
 end
 
-defaults = {
-  '-Xms' => '-Xms256m',
-  '-Xmx' => '-Xmx1g',
-  'UseParNewGC' => '-XX:+UseParNewGC',
-  'UseConcMarkSweepGC' => '-XX:+UseConcMarkSweepGC',
-  'CMSInitiatingOccupancyFraction=' => '-XX:CMSInitiatingOccupancyFraction=75',
-  'UseCMSInitiatingOccupancyOnly' => '-XX:+UseCMSInitiatingOccupancyOnly',
-  'DisableExplicitGC' => '-XX:+DisableExplicitGC',
-  '-Djava.awt.headless=' => '-Djava.awt.headless=true',
-  '-Dfile.encoding=' => '-Dfile.encoding=UTF-8',
-  'HeapDumpOnOutOfMemoryError' => '-XX:+HeapDumpOnOutOfMemoryError',
-}
-
-defaults.each {|k,v| set_default(@jvm_options, k, v)}
+@jvm_options_defaults.each {|k,v| set_default(@jvm_options, k, v)}
 -%>
 
 <% @jvm_options.sort.each do |line| -%>


### PR DESCRIPTION
move the hardcoded defaults to a module argument to allow adapting them with changing the module.
Uses defaults from current upstream branch (8.5)